### PR TITLE
Set $mdb to null on disconnect in static class

### DIFF
--- a/db.class.php
+++ b/db.class.php
@@ -59,7 +59,7 @@ class DB {
   
   // yes, this is ugly. __callStatic() only works in 5.3+
   public static function get() { $args = func_get_args(); return call_user_func_array(array(DB::getMDB(), 'get'), $args); }
-  public static function disconnect() { $args = func_get_args(); return call_user_func_array(array(DB::getMDB(), 'disconnect'), $args); }
+  public static function disconnect() { $args = func_get_args(); DB::$mdb=null; return call_user_func_array(array(DB::getMDB(), 'disconnect'), $args); }
   public static function query() { $args = func_get_args(); return call_user_func_array(array(DB::getMDB(), 'query'), $args); }
   public static function queryFirstRow() { $args = func_get_args(); return call_user_func_array(array(DB::getMDB(), 'queryFirstRow'), $args); }
   public static function queryOneRow() { $args = func_get_args(); return call_user_func_array(array(DB::getMDB(), 'queryOneRow'), $args); }


### PR DESCRIPTION
If static DB::disconnect() is called and afterwards a DB::get() will be
called - No new DB object will be created.

Useful when using in cli for reconnect - after loosing a connection -
ie:
if (!mysqli_ping(\DB::get())) {
\DB::disconnect();
\DB::get();
};
