### PR TITLE
real_escape

### DIFF
--- a/db.class.php
+++ b/db.class.php
@@ -514,6 +514,8 @@ class MeekroDB {
   
   public function escape($str) { return "'" . $this->get()->real_escape_string(strval($str)) . "'"; }
   
+  public function real_escape($str) { return $this->get()->real_escape_string(strval($str)); }
+	
   public function sanitize($value, $type='basic', $hashjoin=', ') {
     if ($type == 'basic') {
       if (is_object($value)) {


### PR DESCRIPTION
If require real_escape without quotes
e.g: $sWhere .= $aColumns[$i]." LIKE '%".$db->real_escape( $_GET['sSearch'] )."%' OR ";