### PR TITLE
Pre sql handler

### DIFF
--- a/db.class.php
+++ b/db.class.php
@@ -443,7 +443,9 @@ class MeekroDB {
       $this->param_char . 'hc',  // hash `key`='value' pairs separated by commas
       $this->param_char . 'ha',  // hash `key`='value' pairs separated by and
       $this->param_char . 'ho',  // hash `key`='value' pairs separated by or
-      $this->param_char . 'ss'  // search string (like string, surrounded with %'s)
+      $this->param_char . 'ss',  // search string (like string, surrounded with %'s)
+      $this->param_char . 'ssb', // search string (like, begins with)
+      $this->param_char . 'sse', // search string (like, ends with)
     );
     
     // generate list of all MeekroDB variables in our query, and their position
@@ -603,6 +605,8 @@ class MeekroDB {
       else if ($type == 'b') $result = $this->formatTableName($arg);
       else if ($type == 'l') $result = $arg;
       else if ($type == 'ss') $result = $this->escape("%" . str_replace(array('%', '_'), array('\%', '\_'), $arg) . "%");
+      else if ($type == 'ssb') $result = $this->escape(str_replace(array('%', '_'), array('\%', '\_'), $arg) . "%");
+      else if ($type == 'sse') $result = $this->escape("%" . str_replace(array('%', '_'), array('\%', '\_'), $arg));
       else if ($type == 't') $result = $this->escape($this->parseTS($arg)); 
       
       else if ($type == 'ls') $result = array_map(array($this, 'escape'), $arg);

--- a/db.class.php
+++ b/db.class.php
@@ -34,6 +34,7 @@ class DB {
   public static $error_handler = true;
   public static $throw_exception_on_error = false;
   public static $nonsql_error_handler = null;
+  public static $pre_sql_handler = false;
   public static $throw_exception_on_nonsql_error = false;
   public static $nested_transactions = false;
   public static $usenull = true;
@@ -43,7 +44,7 @@ class DB {
   // internal
   protected static $mdb = null;
   public static $variables_to_sync = array('param_char', 'named_param_seperator', 'success_handler', 'error_handler', 'throw_exception_on_error',
-    'nonsql_error_handler', 'throw_exception_on_nonsql_error', 'nested_transactions', 'usenull', 'ssl', 'connect_options');
+    'nonsql_error_handler', 'pre_sql_handler', 'throw_exception_on_nonsql_error', 'nested_transactions', 'usenull', 'ssl', 'connect_options');
   
   public static function getMDB() {
     $mdb = DB::$mdb;
@@ -124,6 +125,7 @@ class MeekroDB {
   public $error_handler = true;
   public $throw_exception_on_error = false;
   public $nonsql_error_handler = null;
+  public $pre_sql_handler = false;
   public $throw_exception_on_nonsql_error = false;
   public $nested_transactions = false;
   public $usenull = true;
@@ -672,6 +674,10 @@ class MeekroDB {
     }
 
     $sql = call_user_func_array(array($this, 'parseQueryParams'), $args);
+
+    if ($this->pre_sql_handler !== false && is_callable($this->pre_sql_handler)) {
+      $sql = call_user_func($this->pre_sql_handler, $sql);
+    }
     
     if ($this->success_handler) $starttime = microtime(true);
     $result = $db->query($sql, $is_buffered ? MYSQLI_STORE_RESULT : MYSQLI_USE_RESULT);


### PR DESCRIPTION
Added a pre-sql-handler. The handler is run before the SQL itself so that the raw sql statement can be adjusted with a callback function.

I personally use it together with a back-trace to prefix SQL with a comment of where it has been created. For example:
`/* include/myfile.php:689 */ SELECT ...`

By not using the callback, it doesn't really affect performance more than an if statement. Getting a back-trace can be expensive, but PHP allows a limit parameter which makes it reasonable fast. So fast that I am actually using it on my Live systems as well. But if one doesn't want to use it Live, it's at least very useful in development-environments.

It could potentially be used for other hacks as well.