### PR TITLE
Add a warning to prevent accidents

### DIFF
--- a/simpletest/test.php
+++ b/simpletest/test.php
@@ -28,6 +28,7 @@ ini_set('date.timezone', 'America/Los_Angeles');
 error_reporting(E_ALL | E_STRICT);
 require_once '../db.class.php';
 include 'test_setup.php'; //test config values go here
+// WARNING: ALL tables in the database will be dropped before the tests, including non-test related tables. 
 DB::$user = $set_db_user;
 DB::$password = $set_password;
 DB::$dbName = $set_db;


### PR DESCRIPTION
Add warning mentioning that all tables will be dropped during the test, including non-test related tables, unfortunately just blew away a DB bceause I wasn't expecting that behavior. I was trying to test DB::$error_handler using the official test code because all my attempts to make it work on my PHP 7.4 machine had no effect at all, while I remember it working on older versions of PHP a year or more back.